### PR TITLE
Fix bug

### DIFF
--- a/sourceCode/tetris.c
+++ b/sourceCode/tetris.c
@@ -149,7 +149,6 @@ void remove_line(tetris* t, int line){
     for(i = 0; i < line; i++){
         for (int j = 0; j < t -> width; j++)
             t -> board[line - i][j] = t -> board[line - 1 - i][j]; 
-        // t -> board[line - i] = t -> board[line - 1 - i];
     }
 
     // 맨 윗줄 0으로 초기화

--- a/sourceCode/tetris.c
+++ b/sourceCode/tetris.c
@@ -48,7 +48,7 @@ void tetris_Print(tetris* t){
             && i < t -> posY + t -> current.height
             && t -> current.shape[i - t -> posY][j - t -> posX])
                 printf("■ ");
-            else if(t -> board[i][j] == 1)
+            else if(t -> board[i][j])
                 printf("■ ");
             else
                 printf("  ");

--- a/sourceCode/tetris.c
+++ b/sourceCode/tetris.c
@@ -48,7 +48,7 @@ void tetris_Print(tetris* t){
             && i < t -> posY + t -> current.height
             && t -> current.shape[i - t -> posY][j - t -> posX])
                 printf("■ ");
-            else if(t -> board[i][j])
+            else if(t -> board[i][j] == 1)
                 printf("■ ");
             else
                 printf("  ");
@@ -147,7 +147,9 @@ void remove_line(tetris* t, int line){
 
     // 위에 줄 한칸 아래로 내리기
     for(i = 0; i < line; i++){
-        t -> board[line - i] = t -> board[line - 1 - i];
+        for (int j = 0; j < t -> width; j++)
+            t -> board[line - i][j] = t -> board[line - 1 - i][j]; 
+        // t -> board[line - i] = t -> board[line - 1 - i];
     }
 
     // 맨 윗줄 0으로 초기화


### PR DESCRIPTION
1. 버그 발생 이유
줄 제거 이후 줄을 한 칸 내리는 부분이 포인터를 할당하는 방식으로 작성되었기 때문에 매번 한 줄 씩 t -> board[0]을 가리키는 포인터로 변하게 됩니다.
17번의 줄 제거가 이루어지고 나면 모든 줄이 t -> board[0]을 가리키는 상태이기 때문에 양 옆 4자리가 채워진 상태가 됩니다.

2. 해결 방법
포인터를 할당하는 방식이 아니라 내부의 값을 바꾸는 방식으로 변경했습니다.